### PR TITLE
Add script update-restart-backend.sh 

### DIFF
--- a/update-restart-backend.sh
+++ b/update-restart-backend.sh
@@ -2,11 +2,11 @@
 
 # Maven
 echo "Executando maven"
-docker run -v ~/.m2:/var/maven/.m2 -v "$(pwd)/source/DSpace-dspace-7.6":/tmp/dspacebuild -w /tmp/dspacebuild -ti --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 mvn -q --no-transfer-progress -Duser.home=/var/maven clean package -P dspace-oai,\!dspace-sword,\!dspace-swordv2,\!dspace-rdf,\!dspace-iiif
+docker run -v ~/.m2:/var/maven/.m2 -v "$(pwd)/source/DSpace-dspace-7.6":/tmp/dspacebuild -w /tmp/dspacebuild -T --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 mvn -q --no-transfer-progress -Duser.home=/var/maven clean package -P dspace-oai,\!dspace-sword,\!dspace-swordv2,\!dspace-rdf,\!dspace-iiif
 
 # Ant
 echo "Executando ant"
-docker run -v ~/.m2:/var/maven/.m2 -v $(pwd)/dspace-install-dir:/dspace -v $(pwd)/source/DSpace-dspace-7.6:/tmp/dspacebuild -w /tmp/dspacebuild -ti --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 /bin/bash -c "wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.gz && tar -xvzf apache-ant-1.10.12-bin.tar.gz && cd dspace/target/dspace-installer && ../../../apache-ant-1.10.12/bin/ant init_installation update_configs update_code update_webapps && cd ../../../ && rm -rf apache-ant-*"
+docker run -v ~/.m2:/var/maven/.m2 -v $(pwd)/dspace-install-dir:/dspace -v $(pwd)/source/DSpace-dspace-7.6:/tmp/dspacebuild -w /tmp/dspacebuild -T --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 /bin/bash -c "wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.gz && tar -xvzf apache-ant-1.10.12-bin.tar.gz && cd dspace/target/dspace-installer && ../../../apache-ant-1.10.12/bin/ant init_installation update_configs update_code update_webapps && cd ../../../ && rm -rf apache-ant-*"
 
 echo "Removendo container dspace7"
 docker rm -f dspace7 || true > /dev/null 2>&1

--- a/update-restart-backend.sh
+++ b/update-restart-backend.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Maven
+echo "Executando maven"
+docker run -v ~/.m2:/var/maven/.m2 -v "$(pwd)/source/DSpace-dspace-7.6":/tmp/dspacebuild -w /tmp/dspacebuild -ti --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 mvn -q --no-transfer-progress -Duser.home=/var/maven clean package -P dspace-oai,\!dspace-sword,\!dspace-swordv2,\!dspace-rdf,\!dspace-iiif
+
+# Ant
+echo "Executando ant"
+docker run -v ~/.m2:/var/maven/.m2 -v $(pwd)/dspace-install-dir:/dspace -v $(pwd)/source/DSpace-dspace-7.6:/tmp/dspacebuild -w /tmp/dspacebuild -ti --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 /bin/bash -c "wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.gz && tar -xvzf apache-ant-1.10.12-bin.tar.gz && cd dspace/target/dspace-installer && ../../../apache-ant-1.10.12/bin/ant init_installation update_configs update_code update_webapps && cd ../../../ && rm -rf apache-ant-*"
+
+echo "Removendo container dspace7"
+docker rm -f dspace7 || true > /dev/null 2>&1
+
+echo "Iniciando container dspace7"
+docker compose -f source/DSpace-dspace-7.6/docker-compose_restart.yml up --build -d

--- a/update-restart-backend.sh
+++ b/update-restart-backend.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+echo "Copiand config/spring..."
+rm -rf ./dspace-install-dir/config/spring
+cp -r ./source/DSpace-dspace-7.6/dspace/config/spring ./dspace-install-dir/config/
+
 # Maven
-echo "Executando maven"
+echo "Executando maven..."
 docker run -v ~/.m2:/var/maven/.m2 -v "$(pwd)/source/DSpace-dspace-7.6":/tmp/dspacebuild -w /tmp/dspacebuild --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 mvn -q --no-transfer-progress -Duser.home=/var/maven clean package -P dspace-oai,\!dspace-sword,\!dspace-swordv2,\!dspace-rdf,\!dspace-iiif
 
 # Ant
-echo "Executando ant"
+echo "Executando ant..."
 docker run -v ~/.m2:/var/maven/.m2 -v $(pwd)/dspace-install-dir:/dspace -v $(pwd)/source/DSpace-dspace-7.6:/tmp/dspacebuild -w /tmp/dspacebuild --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 /bin/bash -c "wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.gz && tar -xvzf apache-ant-1.10.12-bin.tar.gz && cd dspace/target/dspace-installer && ../../../apache-ant-1.10.12/bin/ant init_installation update_configs update_code update_webapps && cd ../../../ && rm -rf apache-ant-*"
 
 echo "Removendo container dspace7"

--- a/update-restart-backend.sh
+++ b/update-restart-backend.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 echo "Copiand config/spring..."
-rm -rf ./dspace-install-dir/config/spring
-cp -r ./source/DSpace-dspace-7.6/dspace/config/spring ./dspace-install-dir/config/
+rm -rf dspace-install-dir/config/spring
+cp -r source/DSpace-dspace-7.6/dspace/config/spring ./dspace-install-dir/config/
 
 # Maven
 echo "Executando maven..."

--- a/update-restart-backend.sh
+++ b/update-restart-backend.sh
@@ -2,11 +2,11 @@
 
 # Maven
 echo "Executando maven"
-docker run -v ~/.m2:/var/maven/.m2 -v "$(pwd)/source/DSpace-dspace-7.6":/tmp/dspacebuild -w /tmp/dspacebuild -T --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 mvn -q --no-transfer-progress -Duser.home=/var/maven clean package -P dspace-oai,\!dspace-sword,\!dspace-swordv2,\!dspace-rdf,\!dspace-iiif
+docker run -v ~/.m2:/var/maven/.m2 -v "$(pwd)/source/DSpace-dspace-7.6":/tmp/dspacebuild -w /tmp/dspacebuild --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 mvn -q --no-transfer-progress -Duser.home=/var/maven clean package -P dspace-oai,\!dspace-sword,\!dspace-swordv2,\!dspace-rdf,\!dspace-iiif
 
 # Ant
 echo "Executando ant"
-docker run -v ~/.m2:/var/maven/.m2 -v $(pwd)/dspace-install-dir:/dspace -v $(pwd)/source/DSpace-dspace-7.6:/tmp/dspacebuild -w /tmp/dspacebuild -T --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 /bin/bash -c "wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.gz && tar -xvzf apache-ant-1.10.12-bin.tar.gz && cd dspace/target/dspace-installer && ../../../apache-ant-1.10.12/bin/ant init_installation update_configs update_code update_webapps && cd ../../../ && rm -rf apache-ant-*"
+docker run -v ~/.m2:/var/maven/.m2 -v $(pwd)/dspace-install-dir:/dspace -v $(pwd)/source/DSpace-dspace-7.6:/tmp/dspacebuild -w /tmp/dspacebuild --rm -e MAVen_CONFIG=/var/maven/.m2 maven:3.8.6-openjdk-11 /bin/bash -c "wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.gz && tar -xvzf apache-ant-1.10.12-bin.tar.gz && cd dspace/target/dspace-installer && ../../../apache-ant-1.10.12/bin/ant init_installation update_configs update_code update_webapps && cd ../../../ && rm -rf apache-ant-*"
 
 echo "Removendo container dspace7"
 docker rm -f dspace7 || true > /dev/null 2>&1


### PR DESCRIPTION
Este script Bash automatiza o processo de preparação, compilação e implantação de uma instância do DSpace utilizando Docker. 

- Primeiramente, ele remove a configuração Spring existente e copia uma nova a partir do diretório-fonte do DSpace. 
- Em seguida, executa a compilação do projeto com o Maven, usando um contêiner Docker com a imagem maven:3.8.6-openjdk-11, ativando o perfil dspace-oai e desativando outros módulos opcionais como sword, rdf e iiif. 
- Após a compilação, o script baixa e extrai o Apache Ant, e executa tarefas como init_installation, update_configs, update_code e update_webapps para preparar o ambiente de instalação. 
- Depois, ele remove o contêiner dspace7, caso já exista, e por fim inicializa um novo contêiner usando o Docker Compose com base no arquivo docker-compose_restart.yml, garantindo que a aplicação esteja atualizada e pronta para uso.